### PR TITLE
Convert to Passing a Collection

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,1 @@
-<% @posts.each do |post| %>
-  <%= render :partial => "post", locals: {:post => post} %>
-<% end %>
+<%= render(@posts) || "There are no blog posts!" %>


### PR DESCRIPTION
This pull request simplifies the rendering logic in the `posts/index.html.erb` view by using the default Rails partial rendering for collections. Now, if there are no posts, a fallback message is displayed.

View rendering improvement:

* [`app/views/posts/index.html.erb`](diffhunk://#diff-2940ba8acf3ebe1e62655323a9159f954851342b3a0c24f75909c0ea81328a62L1-R1): Replaced manual iteration and partial rendering with a single `render(@posts)` call, and added a fallback message when there are no blog posts.